### PR TITLE
Fix "pay" command for unsupported type presets

### DIFF
--- a/payctl/__version__.py
+++ b/payctl/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 1, 0)
+VERSION = (1, 1, 1)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/payctl/payctl.py
+++ b/payctl/payctl.py
@@ -1,19 +1,14 @@
 from argparse import ArgumentParser
 from configparser import ConfigParser
 from collections import OrderedDict
-from substrateinterface import SubstrateInterface
 
 from .utils import *
-
 
 #
 # cmd_list - 'list' subcommand handler.
 #
 def cmd_list(args, config):
-    substrate = SubstrateInterface(
-        url=get_config(args, config, 'rpcurl'),
-        type_registry_preset=get_type_preset(get_config(args, config, 'network'))
-    )
+    substrate = get_substrate_interface(args, config)
 
     active_era = substrate.query(
         module='Staking',
@@ -47,10 +42,7 @@ def cmd_list(args, config):
 # cmd_pay - 'pay' subcommand handler.
 #
 def cmd_pay(args, config):
-    substrate = SubstrateInterface(
-        url=get_config(args, config, 'rpcurl'),
-        type_registry_preset=get_type_preset(get_config(args, config, 'network'))
-    )
+    substrate = get_substrate_interface(args, config)
 
     active_era = substrate.query(
         module='Staking',
@@ -157,6 +149,8 @@ def main():
     args_parser.add_argument("-r", "--rpc-url", dest="rpcurl", help="substrate RPC Url")
     args_parser.add_argument("-n", "--network", dest="network", help="name of the network to connect")
     args_parser.add_argument("-d", "--depth-eras", dest="deptheras", help="depth of eras to include")
+    
+    args_parser.add_argument("-f", "--types-registry-file", dest="typesregistry", help="file with the types of the network to connect")
 
     args_subparsers = args_parser.add_subparsers(title="Commands", help='', dest="command")
 

--- a/payctl/payctl.py
+++ b/payctl/payctl.py
@@ -49,7 +49,7 @@ def cmd_list(args, config):
 def cmd_pay(args, config):
     substrate = SubstrateInterface(
         url=get_config(args, config, 'rpcurl'),
-        type_registry_preset=get_config(args, config, 'network')
+        type_registry_preset=get_type_preset(get_config(args, config, 'network'))
     )
 
     active_era = substrate.query(


### PR DESCRIPTION
# Fix "pay" cmd for unsupported type presets
## Description
It looks like I missed to use the `get_type_preset` utility function on the `pay` command on the last PR... In the process, I also detected that the substrate interface didn't accept external type-registries. Fixing it with an utils function that read a new arg/config item for the file of the type_presets.

## Changes

* Fix "pay" command for unsupported type_preset networks
* Adding `--types-registry-file` arg to define the types for the tool.
* Bumping tool version to `v1.1.1`.
