### PR TITLE
Fix: Get the actual account info for multiple accounts 

### DIFF
--- a/payctl/utils.py
+++ b/payctl/utils.py
@@ -145,7 +145,7 @@ def get_accounts_ledger(substrate, accounts):
             controller_account = substrate.query(
                 module='Staking',
                 storage_function='Bonded',
-                params=[accounts[0]]
+                params=[account]
             )
 
             ledger = substrate.query(


### PR DESCRIPTION
The method was returning always the first account info, and assigning it to the rest of accounts in the configuration. The query should take the `account` variable to loop through all the accounts.